### PR TITLE
support decoding uppercase bolt11 values

### DIFF
--- a/decodepay.go
+++ b/decodepay.go
@@ -21,7 +21,7 @@ func Decodepay(bolt11 string) (Bolt11, error) {
 		return Bolt11{}, errors.New("invalid bolt11 invoice")
 	}
 
-    bolt11 = strings.ToLower(bolt11)
+ 	bolt11 = strings.ToLower(bolt11)
 
 	chainPrefix := bolt11[2:firstNumber]
 	chain := &chaincfg.Params{

--- a/decodepay.go
+++ b/decodepay.go
@@ -21,6 +21,8 @@ func Decodepay(bolt11 string) (Bolt11, error) {
 		return Bolt11{}, errors.New("invalid bolt11 invoice")
 	}
 
+    bolt11 = strings.ToLower(bolt11)
+
 	chainPrefix := bolt11[2:firstNumber]
 	chain := &chaincfg.Params{
 		Bech32HRPSegwit: chainPrefix,

--- a/decodepay_test.go
+++ b/decodepay_test.go
@@ -2,6 +2,7 @@ package decodepay
 
 import (
 	"testing"
+	"strings"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -26,6 +27,12 @@ func TestDecodepay(t *testing.T) {
 		actual, err := Decodepay(bolt11)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
+
+        bolt11 = strings.ToUpper(bolt11)
+        actual, err = Decodepay(bolt11)
+        assert.NoError(t, err)
+        assert.Equal(t, expected, actual)
+
 	})
 
 	t.Run("Returns error for invalid bolt11 invoice", func(t *testing.T) {

--- a/decodepay_test.go
+++ b/decodepay_test.go
@@ -28,10 +28,10 @@ func TestDecodepay(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 
-        bolt11 = strings.ToUpper(bolt11)
-        actual, err = Decodepay(bolt11)
-        assert.NoError(t, err)
-        assert.Equal(t, expected, actual)
+		bolt11 = strings.ToUpper(bolt11)
+        	actual, err = Decodepay(bolt11)
+        	assert.NoError(t, err)
+        	assert.Equal(t, expected, actual)
 
 	})
 


### PR DESCRIPTION
According to https://docs.lightning.engineering/the-lightning-network/payment-lifecycle/understanding-lightning-invoices:

"Lightning Network invoices, like other bech32 encoded strings, are typically entirely lowercase. However, there are significant space improvements when encoding uppercase characters only in QR codes, which is why you might encounter uppercase Lightning invoices more frequently. This is also why a Lightning invoice QR code might decode as uppercase only."

So I think this should support decoding also uppercase invoices.
For example Zeus generates invoices in uppercase for QR codes, and when I pay directly with my LND it lands on my list of payments as uppercase.
Then when using for example nostr-wallet-connect for listing transactions (new extensions), it uses this lib for bolt11 decoding and it can't decode.
I think instead of forcing each dependency to remember to lowercase the bolt11 before decoding it, we could just lowercase it here.